### PR TITLE
Provide option to horizontally flip the projection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Optional configuration:
 * `constellations_list` customize which constellations are shown (use names from
   [here](https://github.com/partofthething/ha_skyfield/blob/master/custom_components/ha_skyfield/constellations_by_RA_Dec.dat))
 * `north_up` (boolean) puts North at the top (useful in the Southern Hemisphere)
+* `horizontal_flip` (boolean) flips projection horizontally
 
 Known Issues:
 

--- a/custom_components/ha_skyfield/bodies.py
+++ b/custom_components/ha_skyfield/bodies.py
@@ -45,6 +45,7 @@ class Sky:  # pylint: disable=too-many-instance-attributes
         constellation_list=None,
         planet_list=None,
         north_up=False,
+        horizontal_flip=False,
     ):
         lat, long = latlong
         self._latlong = Topos(latitude_degrees=lat, longitude_degrees=long)
@@ -61,6 +62,7 @@ class Sky:  # pylint: disable=too-many-instance-attributes
         self._show_time = show_time
         self._show_legend = show_legend
         self._north_up = north_up
+        self._horizontal_flip = horizontal_flip
         if constellation_list is None:
             self._constellation_names = constellations.DEFAULT_CONSTELLATIONS
         else:
@@ -167,7 +169,7 @@ class Sky:  # pylint: disable=too-many-instance-attributes
             1, 1, figsize=(6, 6.2), subplot_kw={"projection": "polar"}
         )
         ax.set_axisbelow(True)
-        ax.set_theta_direction(-1)
+        ax.set_theta_direction(1 if self._horizontal_flip else -1)
         ax.plot(*visible, "-", color="k", linewidth=3, alpha=1.0)  # border
 
         self._draw_objects(ax, when)

--- a/custom_components/ha_skyfield/camera.py
+++ b/custom_components/ha_skyfield/camera.py
@@ -28,6 +28,7 @@ CONF_CONSTELLATION_LIST = "constellations_list"
 # could detect north to be up if location is in souther hemisphere
 # but for no we just make it an option
 CONF_NORTH_UP = "north_up"
+CONF_HORIZONTAL_FLIP = "horizontal_flip"
 
 ICON = "mdi:sun"
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
@@ -41,6 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_CONSTELLATION_LIST): cv.ensure_list,
         vol.Optional(CONF_PLANET_LIST): cv.ensure_list,
         vol.Optional(CONF_NORTH_UP): cv.boolean,
+        vol.Optional(CONF_HORIZONTAL_FLIP): cv.boolean,
     }
 )
 
@@ -56,6 +58,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     constellation_list = config.get(CONF_CONSTELLATION_LIST)
     planet_list = config.get(CONF_PLANET_LIST)
     north_up = config.get(CONF_NORTH_UP)
+    horizontal_flip = config.get(CONF_HORIZONTAL_FLIP)
     configdir = hass.config.config_dir
     tmpdir = "/tmp/skyfield"
     _LOGGER.debug("Setting up skyfield.")
@@ -71,6 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         constellation_list,
         planet_list,
         north_up,
+        horizontal_flip,
     )
 
     _LOGGER.debug("Adding skyfield cam")
@@ -93,6 +97,7 @@ class SkyFieldCam(Camera):
         constellations,
         planets,
         north_up,
+        horizontal_flip,
     ):
         Camera.__init__(self)
         from . import bodies
@@ -106,6 +111,7 @@ class SkyFieldCam(Camera):
             constellations,
             planets,
             north_up,
+            horizontal_flip,
         )
         self._loaded = False
         self._configdir = configdir


### PR DESCRIPTION
Assuming northern hemisphere, setting horizontal_flip: true and north_up: true would mimic the view one would have lying on the ground, head toward the North, feet toward the South, as commonly seen in AllSky camera views.

Fixes: #18 

Signed-off-by: Michael J. Kidd <linuxkidd@gmail.com>