### PR TITLE
Switch from PNG to JPG to conserve bandwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Optional configuration:
   [here](https://github.com/partofthething/ha_skyfield/blob/master/custom_components/ha_skyfield/constellations_by_RA_Dec.dat))
 * `north_up` (boolean) puts North at the top (useful in the Southern Hemisphere)
 * `horizontal_flip` (boolean) flips projection horizontally
+* `image_type` (string) Optional - provide image format extension.  Tested options are `png` (default) and `jpg`.
 
 Known Issues:
 

--- a/custom_components/ha_skyfield/bodies.py
+++ b/custom_components/ha_skyfield/bodies.py
@@ -46,6 +46,7 @@ class Sky:  # pylint: disable=too-many-instance-attributes
         planet_list=None,
         north_up=False,
         horizontal_flip=False,
+        image_type="png",
     ):
         lat, long = latlong
         self._latlong = Topos(latitude_degrees=lat, longitude_degrees=long)
@@ -63,6 +64,8 @@ class Sky:  # pylint: disable=too-many-instance-attributes
         self._show_legend = show_legend
         self._north_up = north_up
         self._horizontal_flip = horizontal_flip
+        self._image_type = image_type
+
         if constellation_list is None:
             self._constellation_names = constellations.DEFAULT_CONSTELLATIONS
         else:
@@ -131,6 +134,11 @@ class Sky:  # pylint: disable=too-many-instance-attributes
             linewidth=1,
             alpha=0.8,
         )
+
+    @property
+    def get_image_type(self):
+        """Return the image type attribute."""
+        return self._image_type
 
     def compute_position(self, body, obs_datetime):
         """
@@ -209,7 +217,7 @@ class Sky:  # pylint: disable=too-many-instance-attributes
             plt.show()
         else:
             # filename string or file-like object/buffer
-            fig.savefig(output, format="png")
+            fig.savefig(output, format=self._image_type)
         plt.close()
 
     def _draw_objects(self, ax, when):

--- a/custom_components/ha_skyfield/camera.py
+++ b/custom_components/ha_skyfield/camera.py
@@ -29,6 +29,7 @@ CONF_CONSTELLATION_LIST = "constellations_list"
 # but for no we just make it an option
 CONF_NORTH_UP = "north_up"
 CONF_HORIZONTAL_FLIP = "horizontal_flip"
+CONF_IMAGE_TYPE = "image_type"
 
 ICON = "mdi:sun"
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
@@ -43,6 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_PLANET_LIST): cv.ensure_list,
         vol.Optional(CONF_NORTH_UP): cv.boolean,
         vol.Optional(CONF_HORIZONTAL_FLIP): cv.boolean,
+        vol.Optional(CONF_IMAGE_TYPE): cv.string,
     }
 )
 
@@ -59,6 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     planet_list = config.get(CONF_PLANET_LIST)
     north_up = config.get(CONF_NORTH_UP)
     horizontal_flip = config.get(CONF_HORIZONTAL_FLIP)
+    image_type = config.get(CONF_IMAGE_TYPE)
     configdir = hass.config.config_dir
     tmpdir = "/tmp/skyfield"
     _LOGGER.debug("Setting up skyfield.")
@@ -75,6 +78,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         planet_list,
         north_up,
         horizontal_flip,
+        image_type,
     )
 
     _LOGGER.debug("Adding skyfield cam")
@@ -98,6 +102,7 @@ class SkyFieldCam(Camera):
         planets,
         north_up,
         horizontal_flip,
+        image_type,
     ):
         Camera.__init__(self)
         from . import bodies
@@ -112,6 +117,7 @@ class SkyFieldCam(Camera):
             planets,
             north_up,
             horizontal_flip,
+            image_type,
         )
         self._loaded = False
         self._configdir = configdir

--- a/custom_components/ha_skyfield/sensor.py
+++ b/custom_components/ha_skyfield/sensor.py
@@ -57,7 +57,7 @@ class SkyField(Entity):
     @property
     def entity_picture(self):
         """Return the camera image still."""
-        return "/local/sun.png"
+        return f"/local/sun.{self._file_type}"
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -67,4 +67,4 @@ class SkyField(Entity):
             self.sky.load(self._tmpdir)
             self._loaded = True
         _LOGGER.debug("Updating skyfield plot")
-        self.sky.plot_sky(os.path.join(self._configdir, "www", "sun.png"))
+        self.sky.plot_sky(os.path.join(self._configdir, "www", f"sun.{self.sky.get_image_type}"))


### PR DESCRIPTION
For this project, using PNG doesn't provide valuable visual benefit over a more highly compressed format like JPG.

The bandwidth savings is especially important for remote observatories with limited connectivity options.

```
-rw-r--r-- 1 root root  47K Jan 19 16:59 skyfield.jpg
-rw-r--r-- 1 root root 111K Jan 19 17:03 skyfield.png
```

Additionally, `jpg` compression is generally easier to perform on low power systems like the single board, ARM computers.

Fixes: #20 