### PR TITLE
fix typo from image_type pr

### DIFF
--- a/custom_components/ha_skyfield/sensor.py
+++ b/custom_components/ha_skyfield/sensor.py
@@ -57,7 +57,7 @@ class SkyField(Entity):
     @property
     def entity_picture(self):
         """Return the camera image still."""
-        return f"/local/sun.{self._file_type}"
+        return f"/local/sun.{self.sky.get_image_type}"
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):


### PR DESCRIPTION
correct an early stage prototyping error that was accidentally left in the `image_type` PR #22 

Signed-off-by: Michael J. Kidd <linuxkidd@gmail.com>